### PR TITLE
Improve PWA install button behavior

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -10,6 +10,14 @@ bin/cursor_agent_format_code
 
 **This script automatically handles environment setup and runs all formatting tools with proper error handling.**
 
+### Version Consistency
+- The formatting script uses project dependencies (`npm exec`) instead of global versions to ensure consistency with CI
+- If experiencing formatting differences between local and CI:
+  1. Check that your local Node.js version matches CI
+  2. Run `npm ci` to ensure exact dependency versions
+  3. Set `USE_PROJECT_DEPS=false bin/cursor_agent_format_code` only for debugging
+- **Never mix global and project versions** of formatting tools in the same workflow
+
 ## Code Simplicity
 
 ### Prefer Direct Logic Over Premature Optimization

--- a/.cursorrules
+++ b/.cursorrules
@@ -13,8 +13,10 @@ bin/cursor_agent_format_code
 ## Code Simplicity
 
 ### Prefer Direct Logic Over Premature Optimization
+
 - Avoid unnecessary `useMemo`, `useCallback`, or complex abstractions when simple inline logic suffices
 - Example: Instead of memoizing a simple boolean calculation, use it directly in props:
+
   ```tsx
   // ❌ Unnecessary complexity
   const waitingForInstallEvent = useMemo(() => {
@@ -25,21 +27,25 @@ bin/cursor_agent_format_code
   // ✅ Simple and direct
   loading={installing || (browserDetection && shouldWaitForInstallEvent(browserDetection) && !install)}
   ```
+
 - Prioritize readability and maintainability over micro-optimizations unless performance issues are measured
 
 ### Browser Detection Specifics
+
 - Android devices may not always be detected as "Chrome" browser but can still support `beforeinstallprompt`
 - When checking for PWA install support, check both `result.browser.is("Chrome")` OR `result.os.is("Android")`
 
 ## Project Structure Guidelines
 
 ### `docs/` Directory
+
 - **Purpose**: Documentation for debugging findings, technical decisions, and architectural notes
 - **Naming**: Use "Title Casing With Spaces.md" for readability
 - **Content**: Comprehensive technical documentation that helps future developers understand complex issues, fixes, and decisions
 - **When to create**: After solving complex bugs, implementing significant features, or making architectural decisions
 
-### `bin/` Directory  
+### `bin/` Directory
+
 - **Purpose**: Executable scripts for cursor agents and project automation
 - **For cursor agents**: `bin/cursor_agent_format_code` - Automatic code formatting
 - **Future agent scripts**: Place new cursor agent-specific executables here
@@ -49,6 +55,7 @@ bin/cursor_agent_format_code
 ## Generated Files - DO NOT MODIFY
 
 **NEVER modify these generated files:**
+
 - `typings/generated/auto-import.d.ts` (unplugin-auto-import generated)
 - `app/helpers/routes/generated/**/*.ts` (JsFromRoutes generated)
 - `db/schema.rb` (Rails database schema)
@@ -57,6 +64,7 @@ bin/cursor_agent_format_code
 - Any file with comments indicating it's auto-generated
 
 **If you need to modify functionality related to these files:**
+
 - For auto-imports: Update the import configuration in `vite.config.ts`
 - For routes: Modify the Rails routes in `config/routes.rb`
 - For database: Create a new migration instead of editing schema directly

--- a/.cursorrules
+++ b/.cursorrules
@@ -44,6 +44,31 @@ bin/cursor_agent_format_code
 - Android devices may not always be detected as "Chrome" browser but can still support `beforeinstallprompt`
 - When checking for PWA install support, check both `result.browser.is("Chrome")` OR `result.os.is("Android")`
 
+## Scope Clarification & Communication
+
+### When Asked to Clean Up Code
+
+- **Always distinguish** between:
+  - Code you just added (your new additions)
+  - Pre-existing code (was there before you started)
+  - Actually unused code (not referenced anywhere)
+- **Ask clarifying questions** if scope is unclear before making changes
+- **Keep the core fix separate** from cleanup tasks - don't remove your actual solution when cleaning up
+
+### Code Removal Guidelines
+
+- When told to "remove unused helpers" or similar:
+  1. First identify what was there before you started
+  2. Then identify what you added that's genuinely unused
+  3. **Never remove your core fix/solution** unless explicitly told
+  4. If unclear, ask: "Do you want me to remove my fix or just clean up unused additions?"
+
+### Progressive Simplification
+
+- Start with simple solutions, avoid over-engineering
+- Leverage existing tools (lefthook, package.json scripts) rather than recreating functionality
+- When simplifying, preserve the core functionality while reducing complexity
+
 ## Project Structure Guidelines
 
 ### `docs/` Directory

--- a/.cursorrules
+++ b/.cursorrules
@@ -11,12 +11,13 @@ bin/cursor_agent_format_code
 **This script automatically handles environment setup and runs all formatting tools with proper error handling.**
 
 ### Version Consistency
-- The formatting script uses project dependencies (`npm exec`) instead of global versions to ensure consistency with CI
+
+- The formatting script **always uses project dependencies** (`npm exec`) to ensure 100% consistency with CI
 - If experiencing formatting differences between local and CI:
-  1. Check that your local Node.js version matches CI
-  2. Run `npm ci` to ensure exact dependency versions
-  3. Set `USE_PROJECT_DEPS=false bin/cursor_agent_format_code` only for debugging
-- **Never mix global and project versions** of formatting tools in the same workflow
+  1. Run `npm ci` to ensure exact dependency versions match package-lock.json
+  2. Check that your local Node.js version matches CI (see `.nvmrc` or CI config)
+  3. Verify all formatting tools are listed in `package.json` devDependencies
+- **The script will fail if package.json is missing** - this ensures we never accidentally use global versions
 
 ## Code Simplicity
 

--- a/.cursorrules
+++ b/.cursorrules
@@ -10,6 +10,27 @@ bin/cursor_agent_format_code
 
 **This script automatically handles environment setup and runs all formatting tools with proper error handling.**
 
+## Code Simplicity
+
+### Prefer Direct Logic Over Premature Optimization
+- Avoid unnecessary `useMemo`, `useCallback`, or complex abstractions when simple inline logic suffices
+- Example: Instead of memoizing a simple boolean calculation, use it directly in props:
+  ```tsx
+  // ❌ Unnecessary complexity
+  const waitingForInstallEvent = useMemo(() => {
+    if (!browserDetection) return false;
+    return shouldWaitForInstallEvent(browserDetection) && !install;
+  }, [browserDetection, install]);
+
+  // ✅ Simple and direct
+  loading={installing || (browserDetection && shouldWaitForInstallEvent(browserDetection) && !install)}
+  ```
+- Prioritize readability and maintainability over micro-optimizations unless performance issues are measured
+
+### Browser Detection Specifics
+- Android devices may not always be detected as "Chrome" browser but can still support `beforeinstallprompt`
+- When checking for PWA install support, check both `result.browser.is("Chrome")` OR `result.os.is("Android")`
+
 ## Project Structure Guidelines
 
 ### `docs/` Directory

--- a/app/components/UniversePageInstallAlert.tsx
+++ b/app/components/UniversePageInstallAlert.tsx
@@ -5,6 +5,7 @@ import {
   canOpenUrlInMobileSafari,
   isDesktop,
   isMobileStandaloneBrowser,
+  shouldWaitForInstallEvent,
   useBrowserDetection,
 } from "~/helpers/browsers";
 import { openUniverseInstallationInstructionsInMobileSafari } from "~/helpers/universe";
@@ -24,6 +25,12 @@ const UniversePageInstallAlert: FC<UniversePageInstallAlertProps> = () => {
 
   // == Install to home screen
   const { install, installing } = usePWA();
+
+  // == Determine if we should wait for install event
+  const waitingForInstallEvent = useMemo(() => {
+    if (!browserDetection) return false;
+    return shouldWaitForInstallEvent(browserDetection) && !install;
+  }, [browserDetection, install]);
 
   return (
     <Affix className={classes.affix} position={{}} zIndex={180}>
@@ -47,7 +54,7 @@ const UniversePageInstallAlert: FC<UniversePageInstallAlertProps> = () => {
                   variant="white"
                   size="compact-sm"
                   leftSection={<InstallIcon />}
-                  loading={installing}
+                  loading={installing || waitingForInstallEvent}
                   disabled={!browserDetection}
                   onClick={() => {
                     invariant(browserDetection, "Missing browser detection");

--- a/app/components/UniversePageInstallAlert.tsx
+++ b/app/components/UniversePageInstallAlert.tsx
@@ -26,12 +26,6 @@ const UniversePageInstallAlert: FC<UniversePageInstallAlertProps> = () => {
   // == Install to home screen
   const { install, installing } = usePWA();
 
-  // == Determine if we should wait for install event
-  const waitingForInstallEvent = useMemo(() => {
-    if (!browserDetection) return false;
-    return shouldWaitForInstallEvent(browserDetection) && !install;
-  }, [browserDetection, install]);
-
   return (
     <Affix className={classes.affix} position={{}} zIndex={180}>
       <Transition transition="pop" mounted={isEmpty(modals)} enterDelay={100}>
@@ -54,7 +48,12 @@ const UniversePageInstallAlert: FC<UniversePageInstallAlertProps> = () => {
                   variant="white"
                   size="compact-sm"
                   leftSection={<InstallIcon />}
-                  loading={installing || waitingForInstallEvent}
+                  loading={
+                    installing ||
+                    (browserDetection &&
+                      shouldWaitForInstallEvent(browserDetection) &&
+                      !install)
+                  }
                   disabled={!browserDetection}
                   onClick={() => {
                     invariant(browserDetection, "Missing browser detection");

--- a/app/components/UserPageInstallAlert.tsx
+++ b/app/components/UserPageInstallAlert.tsx
@@ -5,6 +5,7 @@ import {
   canOpenUrlInMobileSafari,
   isDesktop,
   isMobileStandaloneBrowser,
+  shouldWaitForInstallEvent,
   useBrowserDetection,
 } from "~/helpers/browsers";
 import {
@@ -36,6 +37,12 @@ const UserPageInstallAlert: FC<UserPageInstallAlertProps> = ({
   // == Install to home screen
   const { install, installing } = usePWA();
 
+  // == Determine if we should wait for install event
+  const waitingForInstallEvent = useMemo(() => {
+    if (!browserDetection) return false;
+    return shouldWaitForInstallEvent(browserDetection) && !install;
+  }, [browserDetection, install]);
+
   return (
     <Affix className={classes.affix} position={{}} zIndex={180}>
       <Transition
@@ -62,7 +69,7 @@ const UserPageInstallAlert: FC<UserPageInstallAlertProps> = ({
                   variant="white"
                   size="compact-sm"
                   leftSection={<InstallIcon />}
-                  loading={installing}
+                  loading={installing || waitingForInstallEvent}
                   disabled={!browserDetection}
                   onClick={() => {
                     invariant(browserDetection, "Missing browser detection");

--- a/app/components/UserPageInstallAlert.tsx
+++ b/app/components/UserPageInstallAlert.tsx
@@ -5,6 +5,7 @@ import {
   canOpenUrlInMobileSafari,
   isDesktop,
   isMobileStandaloneBrowser,
+  shouldWaitForInstallEvent,
   useBrowserDetection,
 } from "~/helpers/browsers";
 import {
@@ -65,7 +66,7 @@ const UserPageInstallAlert: FC<UserPageInstallAlertProps> = ({
                   loading={
                     installing ||
                     (browserDetection &&
-                      !isDesktop(browserDetection) &&
+                      shouldWaitForInstallEvent(browserDetection) &&
                       !install)
                   }
                   disabled={!browserDetection}

--- a/app/components/UserPageInstallAlert.tsx
+++ b/app/components/UserPageInstallAlert.tsx
@@ -37,12 +37,6 @@ const UserPageInstallAlert: FC<UserPageInstallAlertProps> = ({
   // == Install to home screen
   const { install, installing } = usePWA();
 
-  // == Determine if we should wait for install event
-  const waitingForInstallEvent = useMemo(() => {
-    if (!browserDetection) return false;
-    return shouldWaitForInstallEvent(browserDetection) && !install;
-  }, [browserDetection, install]);
-
   return (
     <Affix className={classes.affix} position={{}} zIndex={180}>
       <Transition
@@ -69,7 +63,12 @@ const UserPageInstallAlert: FC<UserPageInstallAlertProps> = ({
                   variant="white"
                   size="compact-sm"
                   leftSection={<InstallIcon />}
-                  loading={installing || waitingForInstallEvent}
+                  loading={
+                    installing ||
+                    (browserDetection &&
+                      shouldWaitForInstallEvent(browserDetection) &&
+                      !install)
+                  }
                   disabled={!browserDetection}
                   onClick={() => {
                     invariant(browserDetection, "Missing browser detection");

--- a/app/components/UserPageInstallAlert.tsx
+++ b/app/components/UserPageInstallAlert.tsx
@@ -5,7 +5,6 @@ import {
   canOpenUrlInMobileSafari,
   isDesktop,
   isMobileStandaloneBrowser,
-  shouldWaitForInstallEvent,
   useBrowserDetection,
 } from "~/helpers/browsers";
 import {
@@ -66,7 +65,7 @@ const UserPageInstallAlert: FC<UserPageInstallAlertProps> = ({
                   loading={
                     installing ||
                     (browserDetection &&
-                      shouldWaitForInstallEvent(browserDetection) &&
+                      !isDesktop(browserDetection) &&
                       !install)
                   }
                   disabled={!browserDetection}

--- a/app/components/UserPageJoinModal.tsx
+++ b/app/components/UserPageJoinModal.tsx
@@ -5,6 +5,7 @@ import {
   canOpenUrlInMobileSafari,
   isDesktop,
   isMobileStandaloneBrowser,
+  shouldWaitForInstallEvent,
   useBrowserDetection,
 } from "~/helpers/browsers";
 import { openUserPageInstallationInstructionsInMobileSafari } from "~/helpers/userPages";
@@ -45,6 +46,12 @@ const ModalBody: FC<ModalBodyProps> = ({ modalId, currentFriend, user }) => {
 
   // == PWA installation
   const { install, installing } = usePWA();
+
+  // == Determine if we should wait for install event
+  const waitingForInstallEvent = useMemo(() => {
+    if (!browserDetection) return false;
+    return shouldWaitForInstallEvent(browserDetection) && !install;
+  }, [browserDetection, install]);
 
   return (
     <Stack gap="lg" align="center" pb="xs">
@@ -87,7 +94,7 @@ const ModalBody: FC<ModalBodyProps> = ({ modalId, currentFriend, user }) => {
           variant="filled"
           size="md"
           leftSection={<InstallIcon />}
-          loading={installing}
+          loading={installing || waitingForInstallEvent}
           disabled={!browserDetection}
           onClick={() => {
             invariant(browserDetection, "Missing browser detection");

--- a/app/components/UserPageJoinModal.tsx
+++ b/app/components/UserPageJoinModal.tsx
@@ -5,6 +5,7 @@ import {
   canOpenUrlInMobileSafari,
   isDesktop,
   isMobileStandaloneBrowser,
+  shouldWaitForInstallEvent,
   useBrowserDetection,
 } from "~/helpers/browsers";
 import { openUserPageInstallationInstructionsInMobileSafari } from "~/helpers/userPages";
@@ -90,7 +91,7 @@ const ModalBody: FC<ModalBodyProps> = ({ modalId, currentFriend, user }) => {
           loading={
             installing ||
             (browserDetection &&
-              !isDesktop(browserDetection) &&
+              shouldWaitForInstallEvent(browserDetection) &&
               !install)
           }
           disabled={!browserDetection}

--- a/app/components/UserPageJoinModal.tsx
+++ b/app/components/UserPageJoinModal.tsx
@@ -5,7 +5,6 @@ import {
   canOpenUrlInMobileSafari,
   isDesktop,
   isMobileStandaloneBrowser,
-  shouldWaitForInstallEvent,
   useBrowserDetection,
 } from "~/helpers/browsers";
 import { openUserPageInstallationInstructionsInMobileSafari } from "~/helpers/userPages";
@@ -91,7 +90,7 @@ const ModalBody: FC<ModalBodyProps> = ({ modalId, currentFriend, user }) => {
           loading={
             installing ||
             (browserDetection &&
-              shouldWaitForInstallEvent(browserDetection) &&
+              !isDesktop(browserDetection) &&
               !install)
           }
           disabled={!browserDetection}

--- a/app/components/UserPageJoinModal.tsx
+++ b/app/components/UserPageJoinModal.tsx
@@ -47,12 +47,6 @@ const ModalBody: FC<ModalBodyProps> = ({ modalId, currentFriend, user }) => {
   // == PWA installation
   const { install, installing } = usePWA();
 
-  // == Determine if we should wait for install event
-  const waitingForInstallEvent = useMemo(() => {
-    if (!browserDetection) return false;
-    return shouldWaitForInstallEvent(browserDetection) && !install;
-  }, [browserDetection, install]);
-
   return (
     <Stack gap="lg" align="center" pb="xs">
       <Stack gap={4}>
@@ -94,7 +88,12 @@ const ModalBody: FC<ModalBodyProps> = ({ modalId, currentFriend, user }) => {
           variant="filled"
           size="md"
           leftSection={<InstallIcon />}
-          loading={installing || waitingForInstallEvent}
+          loading={
+            installing ||
+            (browserDetection &&
+              shouldWaitForInstallEvent(browserDetection) &&
+              !install)
+          }
           disabled={!browserDetection}
           onClick={() => {
             invariant(browserDetection, "Missing browser detection");

--- a/app/components/WorldPageInstallModal.tsx
+++ b/app/components/WorldPageInstallModal.tsx
@@ -6,7 +6,6 @@ import {
   isDesktop,
   isMobileStandaloneBrowser,
   openUrlInMobileSafari,
-  shouldWaitForInstallEvent,
   useBrowserDetection,
 } from "~/helpers/browsers";
 import { type User } from "~/types";
@@ -59,8 +58,8 @@ const ModalBody: FC<ModalBodyProps> = ({ modalId, currentUser }) => {
           loading={
             installing ||
             (browserDetection &&
-              shouldWaitForInstallEvent(browserDetection) &&
-              !install)
+              !isMobileStandaloneBrowser(browserDetection) &&
+              !canOpenUrlInMobileSafari(browserDetection))
           }
           disabled={
             !browserDetection ||

--- a/app/components/WorldPageInstallModal.tsx
+++ b/app/components/WorldPageInstallModal.tsx
@@ -6,6 +6,7 @@ import {
   isDesktop,
   isMobileStandaloneBrowser,
   openUrlInMobileSafari,
+  shouldWaitForInstallEvent,
   useBrowserDetection,
 } from "~/helpers/browsers";
 import { type User } from "~/types";
@@ -58,8 +59,8 @@ const ModalBody: FC<ModalBodyProps> = ({ modalId, currentUser }) => {
           loading={
             installing ||
             (browserDetection &&
-              !isMobileStandaloneBrowser(browserDetection) &&
-              !canOpenUrlInMobileSafari(browserDetection))
+              shouldWaitForInstallEvent(browserDetection) &&
+              !install)
           }
           disabled={
             !browserDetection ||

--- a/app/components/WorldPageInstallModal.tsx
+++ b/app/components/WorldPageInstallModal.tsx
@@ -42,12 +42,6 @@ const ModalBody: FC<ModalBodyProps> = ({ modalId, currentUser }) => {
   // == PWA installation
   const { install, installing, isStandalone, outOfPWAScope } = usePWA();
 
-  // == Determine if we should wait for install event
-  const waitingForInstallEvent = useMemo(() => {
-    if (!browserDetection) return false;
-    return shouldWaitForInstallEvent(browserDetection) && !install;
-  }, [browserDetection, install]);
-
   return (
     <Stack gap="lg" align="center" pb="xs">
       <HomeScreenPreview
@@ -62,7 +56,12 @@ const ModalBody: FC<ModalBodyProps> = ({ modalId, currentUser }) => {
         <Button
           size="md"
           leftSection={<InstallIcon />}
-          loading={installing || waitingForInstallEvent}
+          loading={
+            installing ||
+            (browserDetection &&
+              shouldWaitForInstallEvent(browserDetection) &&
+              !install)
+          }
           disabled={
             !browserDetection ||
             (!install &&

--- a/app/components/WorldPageInstallModal.tsx
+++ b/app/components/WorldPageInstallModal.tsx
@@ -6,6 +6,7 @@ import {
   isDesktop,
   isMobileStandaloneBrowser,
   openUrlInMobileSafari,
+  shouldWaitForInstallEvent,
   useBrowserDetection,
 } from "~/helpers/browsers";
 import { type User } from "~/types";
@@ -41,6 +42,12 @@ const ModalBody: FC<ModalBodyProps> = ({ modalId, currentUser }) => {
   // == PWA installation
   const { install, installing, isStandalone, outOfPWAScope } = usePWA();
 
+  // == Determine if we should wait for install event
+  const waitingForInstallEvent = useMemo(() => {
+    if (!browserDetection) return false;
+    return shouldWaitForInstallEvent(browserDetection) && !install;
+  }, [browserDetection, install]);
+
   return (
     <Stack gap="lg" align="center" pb="xs">
       <HomeScreenPreview
@@ -55,7 +62,7 @@ const ModalBody: FC<ModalBodyProps> = ({ modalId, currentUser }) => {
         <Button
           size="md"
           leftSection={<InstallIcon />}
-          loading={installing}
+          loading={installing || waitingForInstallEvent}
           disabled={
             !browserDetection ||
             (!install &&

--- a/app/helpers/browsers.ts
+++ b/app/helpers/browsers.ts
@@ -26,7 +26,7 @@ export const isDesktopChrome = (result: IResult): boolean =>
 
 // Helper function to check if we should wait for the install event
 export const shouldWaitForInstallEvent = (result: IResult): boolean =>
-  result.browser.is("Chrome");
+  result.browser.is("Chrome") || result.os.is("Android");
 
 const canUseIosShortcutsExploit = (result: IResult): boolean =>
   isIos(result) &&

--- a/app/helpers/browsers.ts
+++ b/app/helpers/browsers.ts
@@ -1,3 +1,4 @@
+import { randomId } from "@mantine/hooks";
 import { type IResult, UAParser } from "ua-parser-js";
 
 export const useBrowserDetection = (): IResult | undefined => {
@@ -16,9 +17,8 @@ export const detectBrowser = (): IResult => {
 export const isIos = (result: IResult): boolean => result.os.is("iOS");
 export const isAndroid = (result: IResult): boolean => result.os.is("Android");
 
-// Helper function to check if we should wait for the install event
-export const shouldWaitForInstallEvent = (result: IResult): boolean =>
-  result.browser.is("Chrome") || result.os.is("Android");
+export const isMobileChrome = (result: IResult): boolean =>
+  result.browser.is("Mobile Chrome");
 
 const canUseIosShortcutsExploit = (result: IResult): boolean =>
   isIos(result) &&
@@ -34,3 +34,14 @@ export const isDesktop = (result: IResult): boolean =>
 export const canOpenUrlInMobileSafari = (result: IResult): boolean =>
   isIos(result) &&
   (!result.browser.is("Instagram") || canUseIosShortcutsExploit(result));
+
+export const openUrlInMobileSafari = (url: string): void => {
+  const parser = new UAParser();
+  const result = parser.getResult();
+  const parsedUrl = hrefToUrl(url);
+  if (result.browser.is("Instagram") && canUseIosShortcutsExploit(result)) {
+    location.href = `shortcuts://x-callback-url/run-shortcut?name=${randomId()}&x-error=${encodeURIComponent(parsedUrl.toString())}`;
+  } else if (parsedUrl.protocol === "https:") {
+    location.href = `x-safari-${parsedUrl.toString()}`;
+  }
+};

--- a/app/helpers/browsers.ts
+++ b/app/helpers/browsers.ts
@@ -20,6 +20,10 @@ export const isAndroid = (result: IResult): boolean => result.os.is("Android");
 export const isMobileChrome = (result: IResult): boolean =>
   result.browser.is("Mobile Chrome");
 
+// Helper function to check if we should wait for the install event
+export const shouldWaitForInstallEvent = (result: IResult): boolean =>
+  result.browser.is("Chrome") || result.os.is("Android");
+
 const canUseIosShortcutsExploit = (result: IResult): boolean =>
   isIos(result) &&
   !!result.os.version &&

--- a/app/helpers/browsers.ts
+++ b/app/helpers/browsers.ts
@@ -22,14 +22,11 @@ export const isMobileChrome = (result: IResult): boolean =>
 
 // Helper function to detect if browser supports beforeinstallprompt
 export const isDesktopChrome = (result: IResult): boolean =>
-  isDesktop(result) && result.browser.is("Chrome");
+  result.browser.is("Chrome");
 
-export const supportsBeforeInstallPrompt = (result: IResult): boolean =>
-  isAndroid(result) || isDesktopChrome(result);
-
-// Helper function to determine if we should wait for install event
+// Helper function to check if we should wait for the install event
 export const shouldWaitForInstallEvent = (result: IResult): boolean =>
-  supportsBeforeInstallPrompt(result);
+  result.browser.is("Chrome");
 
 const canUseIosShortcutsExploit = (result: IResult): boolean =>
   isIos(result) &&

--- a/app/helpers/browsers.ts
+++ b/app/helpers/browsers.ts
@@ -1,4 +1,3 @@
-import { randomId } from "@mantine/hooks";
 import { type IResult, UAParser } from "ua-parser-js";
 
 export const useBrowserDetection = (): IResult | undefined => {
@@ -16,13 +15,6 @@ export const detectBrowser = (): IResult => {
 
 export const isIos = (result: IResult): boolean => result.os.is("iOS");
 export const isAndroid = (result: IResult): boolean => result.os.is("Android");
-
-export const isMobileChrome = (result: IResult): boolean =>
-  result.browser.is("Mobile Chrome");
-
-// Helper function to detect if browser supports beforeinstallprompt
-export const isDesktopChrome = (result: IResult): boolean =>
-  result.browser.is("Chrome");
 
 // Helper function to check if we should wait for the install event
 export const shouldWaitForInstallEvent = (result: IResult): boolean =>
@@ -42,14 +34,3 @@ export const isDesktop = (result: IResult): boolean =>
 export const canOpenUrlInMobileSafari = (result: IResult): boolean =>
   isIos(result) &&
   (!result.browser.is("Instagram") || canUseIosShortcutsExploit(result));
-
-export const openUrlInMobileSafari = (url: string): void => {
-  const parser = new UAParser();
-  const result = parser.getResult();
-  const parsedUrl = hrefToUrl(url);
-  if (result.browser.is("Instagram") && canUseIosShortcutsExploit(result)) {
-    location.href = `shortcuts://x-callback-url/run-shortcut?name=${randomId()}&x-error=${encodeURIComponent(parsedUrl.toString())}`;
-  } else if (parsedUrl.protocol === "https:") {
-    location.href = `x-safari-${parsedUrl.toString()}`;
-  }
-};

--- a/app/helpers/browsers.ts
+++ b/app/helpers/browsers.ts
@@ -20,6 +20,17 @@ export const isAndroid = (result: IResult): boolean => result.os.is("Android");
 export const isMobileChrome = (result: IResult): boolean =>
   result.browser.is("Mobile Chrome");
 
+// Helper function to detect if browser supports beforeinstallprompt
+export const isDesktopChrome = (result: IResult): boolean =>
+  isDesktop(result) && result.browser.is("Chrome");
+
+export const supportsBeforeInstallPrompt = (result: IResult): boolean =>
+  isAndroid(result) || isDesktopChrome(result);
+
+// Helper function to determine if we should wait for install event
+export const shouldWaitForInstallEvent = (result: IResult): boolean =>
+  supportsBeforeInstallPrompt(result);
+
 const canUseIosShortcutsExploit = (result: IResult): boolean =>
   isIos(result) &&
   !!result.os.version &&

--- a/app/helpers/mantine.module.css
+++ b/app/helpers/mantine.module.css
@@ -3,9 +3,9 @@
 @layer components {
   .button {
     &:where(
-      :disabled:not([data-loading]),
-      [data-disabled]:not([data-loading])
-    ) {
+        :disabled:not([data-loading]),
+        [data-disabled]:not([data-loading])
+      ) {
       @mixin dark-user-theme {
         color: var(--mantine-color-dark-2);
         background-color: alpha(var(--mantine-color-black), 0.4);

--- a/app/helpers/mantine.module.css
+++ b/app/helpers/mantine.module.css
@@ -3,9 +3,9 @@
 @layer components {
   .button {
     &:where(
-        :disabled:not([data-loading]),
-        [data-disabled]:not([data-loading])
-      ) {
+      :disabled:not([data-loading]),
+      [data-disabled]:not([data-loading])
+    ) {
       @mixin dark-user-theme {
         color: var(--mantine-color-dark-2);
         background-color: alpha(var(--mantine-color-black), 0.4);

--- a/bin/cursor_agent_format_code
+++ b/bin/cursor_agent_format_code
@@ -13,32 +13,74 @@ if command -v nodenv >/dev/null 2>&1; then
   eval "$(nodenv init -)"
 fi
 
-# Use project dependencies instead of global npx to ensure version consistency
+# Function to check if a package is available
+check_package() {
+  local package_name="$1"
+  local use_project="$2"
+  
+  if [ "$use_project" = "true" ]; then
+    npm list "$package_name" >/dev/null 2>&1
+  else
+    command -v "$package_name" >/dev/null 2>&1
+  fi
+}
+
+# Function to get command with fallback
+get_command() {
+  local package_name="$1"
+  local use_project="$2"
+  
+  if [ "$use_project" = "true" ] && check_package "$package_name" true; then
+    echo "npm exec -- $package_name"
+  elif check_package "$package_name" false; then
+    echo "npx $package_name"
+  else
+    echo ""
+  fi
+}
+
+# Use project dependencies by default, fall back to global if needed
 USE_PROJECT_DEPS=${USE_PROJECT_DEPS:-true}
 
-if [ "$USE_PROJECT_DEPS" = "true" ]; then
-  PRETTIER_CMD="npm exec -- prettier"
-  ESLINT_CMD="npm exec -- eslint"
-  LEFTHOOK_CMD="npm exec -- lefthook"
-else
-  PRETTIER_CMD="npx prettier"
-  ESLINT_CMD="npx eslint"
-  LEFTHOOK_CMD="npx lefthook"
+# Check if package.json exists (we're in a Node.js project)
+if [ ! -f "package.json" ]; then
+  echo "⚠️ No package.json found, using global tools..."
+  USE_PROJECT_DEPS=false
 fi
 
-echo "✨ Formatting frontend files (JS/TS/CSS/Markdown)..."
-$PRETTIER_CMD --write '**/*.{js,jsx,ts,tsx,css,md,html,json,yaml,yml}' || {
-  echo "⚠️ Prettier formatting failed, but continuing..."
-}
+# Get commands with automatic fallback
+PRETTIER_CMD=$(get_command "prettier" "$USE_PROJECT_DEPS")
+ESLINT_CMD=$(get_command "eslint" "$USE_PROJECT_DEPS")
+LEFTHOOK_CMD=$(get_command "lefthook" "$USE_PROJECT_DEPS")
 
-echo "🧹 Running ESLint auto-fix..."
-$ESLINT_CMD --fix '**/*.{js,jsx,ts,tsx}' || {
-  echo "⚠️ ESLint auto-fix failed, but continuing..."
-}
+# Format with Prettier
+if [ -n "$PRETTIER_CMD" ]; then
+  echo "✨ Formatting frontend files (JS/TS/CSS/Markdown)..."
+  $PRETTIER_CMD --write '**/*.{js,jsx,ts,tsx,css,md,html,json,yaml,yml}' 2>/dev/null || {
+    echo "⚠️ Prettier formatting failed, but continuing..."
+  }
+else
+  echo "⚠️ Prettier not found, skipping frontend formatting..."
+fi
 
-echo "🚀 Running lefthook formatting..."
-$LEFTHOOK_CMD run fix || {
-  echo "⚠️ Lefthook failed, but frontend formatting completed"
-}
+# ESLint auto-fix
+if [ -n "$ESLINT_CMD" ]; then
+  echo "🧹 Running ESLint auto-fix..."
+  $ESLINT_CMD --fix '**/*.{js,jsx,ts,tsx}' 2>/dev/null || {
+    echo "⚠️ ESLint auto-fix failed, but continuing..."
+  }
+else
+  echo "⚠️ ESLint not found, skipping auto-fix..."
+fi
+
+# Lefthook formatting
+if [ -n "$LEFTHOOK_CMD" ]; then
+  echo "🚀 Running lefthook formatting..."
+  $LEFTHOOK_CMD run fix 2>/dev/null || {
+    echo "⚠️ Lefthook failed, but frontend formatting completed"
+  }
+elif [ -f "lefthook.yml" ]; then
+  echo "⚠️ Lefthook config found but command not available, skipping..."
+fi
 
 echo "✅ Formatting complete!"

--- a/bin/cursor_agent_format_code
+++ b/bin/cursor_agent_format_code
@@ -13,45 +13,33 @@ if command -v nodenv >/dev/null 2>&1; then
   eval "$(nodenv init -)"
 fi
 
-# Function to check if a package is available
-check_package() {
+# Check if package.json exists (we're in a Node.js project)
+if [ ! -f "package.json" ]; then
+  echo "❌ No package.json found. This script requires a Node.js project with dependencies."
+  exit 1
+fi
+
+# Function to check if a package is available in project dependencies
+check_project_package() {
   local package_name="$1"
-  local use_project="$2"
-  
-  if [ "$use_project" = "true" ]; then
-    npm list "$package_name" >/dev/null 2>&1
-  else
-    command -v "$package_name" >/dev/null 2>&1
-  fi
+  npm list "$package_name" >/dev/null 2>&1
 }
 
-# Function to get command with fallback
-get_command() {
+# Function to get project command or warn if missing
+get_project_command() {
   local package_name="$1"
-  local use_project="$2"
   
-  if [ "$use_project" = "true" ] && check_package "$package_name" true; then
+  if check_project_package "$package_name"; then
     echo "npm exec -- $package_name"
-  elif check_package "$package_name" false; then
-    echo "npx $package_name"
   else
     echo ""
   fi
 }
 
-# Use project dependencies by default, fall back to global if needed
-USE_PROJECT_DEPS=${USE_PROJECT_DEPS:-true}
-
-# Check if package.json exists (we're in a Node.js project)
-if [ ! -f "package.json" ]; then
-  echo "⚠️ No package.json found, using global tools..."
-  USE_PROJECT_DEPS=false
-fi
-
-# Get commands with automatic fallback
-PRETTIER_CMD=$(get_command "prettier" "$USE_PROJECT_DEPS")
-ESLINT_CMD=$(get_command "eslint" "$USE_PROJECT_DEPS")
-LEFTHOOK_CMD=$(get_command "lefthook" "$USE_PROJECT_DEPS")
+# Always use project dependencies for consistency with CI
+PRETTIER_CMD=$(get_project_command "prettier")
+ESLINT_CMD=$(get_project_command "eslint")
+LEFTHOOK_CMD=$(get_project_command "lefthook")
 
 # Format with Prettier
 if [ -n "$PRETTIER_CMD" ]; then
@@ -60,7 +48,7 @@ if [ -n "$PRETTIER_CMD" ]; then
     echo "⚠️ Prettier formatting failed, but continuing..."
   }
 else
-  echo "⚠️ Prettier not found, skipping frontend formatting..."
+  echo "⚠️ Prettier not found in project dependencies, skipping frontend formatting..."
 fi
 
 # ESLint auto-fix
@@ -70,7 +58,7 @@ if [ -n "$ESLINT_CMD" ]; then
     echo "⚠️ ESLint auto-fix failed, but continuing..."
   }
 else
-  echo "⚠️ ESLint not found, skipping auto-fix..."
+  echo "⚠️ ESLint not found in project dependencies, skipping auto-fix..."
 fi
 
 # Lefthook formatting
@@ -80,7 +68,7 @@ if [ -n "$LEFTHOOK_CMD" ]; then
     echo "⚠️ Lefthook failed, but frontend formatting completed"
   }
 elif [ -f "lefthook.yml" ]; then
-  echo "⚠️ Lefthook config found but command not available, skipping..."
+  echo "⚠️ Lefthook config found but not installed in project dependencies, skipping..."
 fi
 
 echo "✅ Formatting complete!"

--- a/bin/cursor_agent_format_code
+++ b/bin/cursor_agent_format_code
@@ -13,62 +13,19 @@ if command -v nodenv >/dev/null 2>&1; then
   eval "$(nodenv init -)"
 fi
 
-# Check if package.json exists (we're in a Node.js project)
+# Check if package.json exists
 if [ ! -f "package.json" ]; then
-  echo "❌ No package.json found. This script requires a Node.js project with dependencies."
+  echo "❌ No package.json found. This script requires a Node.js project."
   exit 1
 fi
 
-# Function to check if a package is available in project dependencies
-check_project_package() {
-  local package_name="$1"
-  npm list "$package_name" >/dev/null 2>&1
-}
+echo "✨ Formatting with prettier..."
+npm exec -- prettier --write '**/*.{js,jsx,ts,tsx,css,md,html,json,yaml,yml}' 2>/dev/null || echo "⚠️ Prettier failed or not installed"
 
-# Function to get project command or warn if missing
-get_project_command() {
-  local package_name="$1"
-  
-  if check_project_package "$package_name"; then
-    echo "npm exec -- $package_name"
-  else
-    echo ""
-  fi
-}
+echo "🧹 Running ESLint auto-fix..."
+npm exec -- eslint --fix '**/*.{js,jsx,ts,tsx}' 2>/dev/null || echo "⚠️ ESLint failed or not installed"
 
-# Always use project dependencies for consistency with CI
-PRETTIER_CMD=$(get_project_command "prettier")
-ESLINT_CMD=$(get_project_command "eslint")
-LEFTHOOK_CMD=$(get_project_command "lefthook")
-
-# Format with Prettier
-if [ -n "$PRETTIER_CMD" ]; then
-  echo "✨ Formatting frontend files (JS/TS/CSS/Markdown)..."
-  $PRETTIER_CMD --write '**/*.{js,jsx,ts,tsx,css,md,html,json,yaml,yml}' 2>/dev/null || {
-    echo "⚠️ Prettier formatting failed, but continuing..."
-  }
-else
-  echo "⚠️ Prettier not found in project dependencies, skipping frontend formatting..."
-fi
-
-# ESLint auto-fix
-if [ -n "$ESLINT_CMD" ]; then
-  echo "🧹 Running ESLint auto-fix..."
-  $ESLINT_CMD --fix '**/*.{js,jsx,ts,tsx}' 2>/dev/null || {
-    echo "⚠️ ESLint auto-fix failed, but continuing..."
-  }
-else
-  echo "⚠️ ESLint not found in project dependencies, skipping auto-fix..."
-fi
-
-# Lefthook formatting
-if [ -n "$LEFTHOOK_CMD" ]; then
-  echo "🚀 Running lefthook formatting..."
-  $LEFTHOOK_CMD run fix 2>/dev/null || {
-    echo "⚠️ Lefthook failed, but frontend formatting completed"
-  }
-elif [ -f "lefthook.yml" ]; then
-  echo "⚠️ Lefthook config found but not installed in project dependencies, skipping..."
-fi
+echo "🚀 Running lefthook..."
+npm exec -- lefthook run fix 2>/dev/null || echo "⚠️ Lefthook failed or not installed"
 
 echo "✅ Formatting complete!"

--- a/bin/cursor_agent_format_code
+++ b/bin/cursor_agent_format_code
@@ -5,15 +5,7 @@
 
 set -e
 
-echo "🔧 Setting up environment..."
-
-# Setup Node.js
-export PATH="$HOME/.nodenv/bin:$PATH"
-if command -v nodenv >/dev/null 2>&1; then
-  eval "$(nodenv init -)"
-fi
-
-echo "🚀 Running lefthook formatting..."
+echo " Running lefthook formatting..."
 npx lefthook run fix
 
 echo "✅ Formatting complete!"

--- a/bin/cursor_agent_format_code
+++ b/bin/cursor_agent_format_code
@@ -13,18 +13,31 @@ if command -v nodenv >/dev/null 2>&1; then
   eval "$(nodenv init -)"
 fi
 
+# Use project dependencies instead of global npx to ensure version consistency
+USE_PROJECT_DEPS=${USE_PROJECT_DEPS:-true}
+
+if [ "$USE_PROJECT_DEPS" = "true" ]; then
+  PRETTIER_CMD="npm exec -- prettier"
+  ESLINT_CMD="npm exec -- eslint"
+  LEFTHOOK_CMD="npm exec -- lefthook"
+else
+  PRETTIER_CMD="npx prettier"
+  ESLINT_CMD="npx eslint"
+  LEFTHOOK_CMD="npx lefthook"
+fi
+
 echo "✨ Formatting frontend files (JS/TS/CSS/Markdown)..."
-npx prettier --write '**/*.{js,jsx,ts,tsx,css,md,html,json,yaml,yml}' || {
+$PRETTIER_CMD --write '**/*.{js,jsx,ts,tsx,css,md,html,json,yaml,yml}' || {
   echo "⚠️ Prettier formatting failed, but continuing..."
 }
 
 echo "🧹 Running ESLint auto-fix..."
-npx eslint --fix '**/*.{js,jsx,ts,tsx}' || {
+$ESLINT_CMD --fix '**/*.{js,jsx,ts,tsx}' || {
   echo "⚠️ ESLint auto-fix failed, but continuing..."
 }
 
 echo "🚀 Running lefthook formatting..."
-npx lefthook run fix || {
+$LEFTHOOK_CMD run fix || {
   echo "⚠️ Lefthook failed, but frontend formatting completed"
 }
 

--- a/bin/cursor_agent_format_code
+++ b/bin/cursor_agent_format_code
@@ -13,19 +13,7 @@ if command -v nodenv >/dev/null 2>&1; then
   eval "$(nodenv init -)"
 fi
 
-# Check if package.json exists
-if [ ! -f "package.json" ]; then
-  echo "❌ No package.json found. This script requires a Node.js project."
-  exit 1
-fi
-
-echo "✨ Formatting with prettier..."
-npm exec -- prettier --write '**/*.{js,jsx,ts,tsx,css,md,html,json,yaml,yml}' 2>/dev/null || echo "⚠️ Prettier failed or not installed"
-
-echo "🧹 Running ESLint auto-fix..."
-npm exec -- eslint --fix '**/*.{js,jsx,ts,tsx}' 2>/dev/null || echo "⚠️ ESLint failed or not installed"
-
-echo "🚀 Running lefthook..."
-npm exec -- lefthook run fix 2>/dev/null || echo "⚠️ Lefthook failed or not installed"
+echo "🚀 Running lefthook formatting..."
+npx lefthook run fix
 
 echo "✅ Formatting complete!"


### PR DESCRIPTION
Implement a loading state for PWA install buttons on Android and Desktop Chrome.

Previously, Android and Desktop Chrome users would see iOS-specific PWA installation instructions and a "Let's do it" button while the browser waited for the `beforeinstallprompt` event to fire. This caused confusion. Now, a loading spinner is displayed until the native install prompt is ready.