### PR TITLE
Remove image authorization check in controller

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -6,7 +6,6 @@ class ImagesController < ApplicationController
   # GET /images/:signed_id
   def show
     image = maybe_find_image
-    authorize!(image) if image
     render(json: {
       image: ImageSerializer.one_if(image),
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "smallerworld",
+  "name": "workspace",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Remove the authorization check for showing images in `ImagesController`.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e9d4027-d235-45cb-98eb-82b2ec82141f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1e9d4027-d235-45cb-98eb-82b2ec82141f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

