### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,7 @@
 name: deploy
 run-name: "Deploy from ${{ github.event.workflow_run.head_branch }} (${{ github.event.workflow_run.head_commit.message }})"
+permissions:
+  contents: read
 
 on:
   workflow_run:


### PR DESCRIPTION
Potential fix for [https://github.com/hulloitskai/smallerworld/security/code-scanning/3](https://github.com/hulloitskai/smallerworld/security/code-scanning/3)

**General Approach:**  
Add a `permissions` block at the top/root of the workflow (after the `name:` line), which will apply least-privilege permissions to all jobs unless individually overridden. If the jobs only require reading contents (as appears to be the case here), set `permissions: { contents: read }` at the workflow root.

**Detailed Instructions:**  
- Edit `.github/workflows/deploy.yml`.
- Insert a `permissions:` block after the `name:` and `run-name:` fields and before `on:`.
- Set the contents of the block to:
  ```yaml
  permissions:
    contents: read
  ```
- This will ensure all jobs in this workflow will only grant the GITHUB_TOKEN read access to repository contents.
- If future steps require elevated permissions, those can be added at the job level as needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
